### PR TITLE
add "clickToOpen" property with default true

### DIFF
--- a/addon/components/cp-panel/component.js
+++ b/addon/components/cp-panel/component.js
@@ -10,6 +10,8 @@ export default Ember.Component.extend({
   dependencyChecker: Ember.inject.service(),
   shouldAnimate: Ember.computed.and('dependencyChecker.hasLiquidFire', 'animate'),
 
+  clickToOpen: true,
+
   group: null, // passed in if rendered as part of a {{cp-panels}} group
 
   classNames: ['cp-Panel'],
@@ -52,7 +54,9 @@ export default Ember.Component.extend({
 
   actions: {
     toggleIsOpen() {
-      this.get('panelActions').toggle(this.get('name'));
+      if (this.get('clickToOpen')) {
+        this.get('panelActions').toggle(this.get('name'));
+      }
     }
   }
 });


### PR DESCRIPTION
This adds the option to disable the click action leaving only the "open" property to determine whether a panel is open or not. This was for a use case where the panel being open or not was directly tied to a computed property.
